### PR TITLE
rename to zy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,19 +817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mythian"
-version = "0.1.0"
-dependencies = [
- "actix-files",
- "actix-web",
- "clap",
- "color-eyre",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,4 +1536,17 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "zy"
+version = "0.1.0"
+dependencies = [
+ "actix-files",
+ "actix-web",
+ "clap",
+ "color-eyre",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
-name = "mythian"
+name = "zy"
 version = "0.1.0"
-authors = ["The Bulan Developers <dev@bulan.io>"]
+authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
-description = "The bulan.io Backend Server"
-repository = "https://github.com/bulan-io/bulan-server"
+rust-version = "1.59.0"
+description = "Minimal and blazing-fast file server."
+repository = "https://github.com/miraclx/zy"
 license = "MIT OR Apache-2.0"
+keywords = ["static", "file", "server", "http", "cli"]
+categories = ["command-line-utilities", "web-programming::http-server"]
 
 [dependencies]
 clap = { version = "3.2", features = ["derive"] }
@@ -15,6 +18,3 @@ actix-web = "4.2.1"
 color-eyre = "0.6.2"
 actix-files = "0.6.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-
-[features]
-shutdown-signal = []

--- a/README.md
+++ b/README.md
@@ -1,65 +1,88 @@
-# Mythian
+# Zy
 
-> The bulan.io Backend Server
+> Minimal and blazing-fast file server. For real, this time.
+
+## Features
+
+- [Single Page Application support](https://developer.mozilla.org/en-US/docs/Glossary/SPA)
+- Partial responses ([Range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range) support)
+- Cross-Origin Resource Sharing ([CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS))
+- [Automatic HTTP compression](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) (Gzip, Brotli, Deflate)
+- [Cache control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) (ETag, Last-Modified, Cache-Control)
+- Sane defaults
+  - No access to hidden files
+  - No access to content outside the base directory
+  - No access to symbolic links outside the base directory
 
 ## Installation
 
-- First, install Rust and Cargo. See <https://rustup.rs/>.
-- Next, clone this repository.
+To install `zy`, you need Rust `1.59.0` or higher. You can then use `cargo` to build everything:
 
-  ```console
-  git clone https://github.com/bulan-io/bulan-server.git
-  ```
+```console
+cargo install zy
+```
+
+You can also install the latest version (or a specific commit) of `zy` directly from GitHub.
+
+```console
+git clone https://github.com/miraclx/zy.git
+cargo install --path zy
+```
 
 ## Usage
 
-- Build the server.
+```console
+zy
+```
 
-  ```console
-  cargo build --release
-  ```
+_This will start serving your current directory on <http://localhost:3000> by default._
 
-  This will export the binary to `target/release/mythian`.
+_...you can also specify a different port or base directory:_
 
-  </details>
+```console
+zy /path/to/serve
+```
 
-- Run the server.
+_...or perhaps different addresses:_
 
-  ```console
-  ./target/release/mythian
-  ```
+```console
+zy -l 5000 -l 127.0.0.1:8080 -l 192.168.1.25
+```
 
-  The server will be running on <http://localhost:3000> by default, and will serve the current directory.
+## Configuration
 
-  <details>
-  <summary> You can view the available configuration options by running <code>./target/release/mythian --help</code>. </summary>
+You can run `zy --help` to see all available options.
 
-  ```console
-  $ ./target/release/mythian --help
-  Mythian 0.1.0
-  The bulan.io Backend Server
+```console
+$ zy --help
+Zy 0.1.0
+Minimal and blazing-fast file server.
 
-  USAGE:
-      mythian [OPTIONS] [DIR]
+USAGE:
+    zy [OPTIONS] [DIR]
 
-  ARGS:
-      <DIR>    Directory to serve [default: .]
+ARGS:
+    <DIR>    Directory to serve [default: .]
 
-  OPTIONS:
-      -l, --listen <URI>    Sets the address to listen on (repeatable)
-                            Valid: `3000`, `127.0.0.1`, `127.0.0.1:3000` [default: 127.0.0.1:3000]
-      -s, --spa             Run as a Single Page Application
-      -i, --index <FILE>    Index file to serve from the base directory [default: index.html]
-          --404 <FILE>      404 file to serve from the base directory [default: 404.html]
-      -c, --cache <SECS>    Cache time (max-age) in seconds [default: 3600]
-          --no-cors         Disable Cross-Origin Resource Sharing (CORS)
-      -a, --all             Serve hidden files
-      -f, --follow-links    Follow symlinks outside of the base directory (unsafe)
-      -v, --verbose         Be verbose
-      -x, --confirm-exit    Require confirmation before exiting on Ctrl+C
-      -h, --help            Print help information
-      -V, --version         Print version information
-  ```
+OPTIONS:
+    -l, --listen <URI>    Sets the address to listen on (repeatable)
+                          Valid: `3000`, `127.0.0.1`, `127.0.0.1:3000` [default: 127.0.0.1:3000]
+    -s, --spa             Run as a Single Page Application
+    -i, --index <FILE>    Index file to serve from the base directory [default: index.html]
+        --404 <FILE>      404 file to serve from the base directory [default: 404.html]
+    -c, --cache <SECS>    Cache time (max-age) in seconds [default: 3600]
+        --no-cors         Disable Cross-Origin Resource Sharing (CORS)
+    -a, --all             Serve hidden files
+    -f, --follow-links    Follow symlinks outside of the base directory (unsafe)
+    -v, --verbose         Be verbose
+    -x, --confirm-exit    Require confirmation before exiting on Ctrl+C
+    -h, --help            Print help information
+    -V, --version         Print version information
+```
+
+## Credits
+
+Zy was originally inspired by [sfz](https://github.com/weihanglo/sfz), [serve](https://github.com/vercel/serve) and [http-server](https://github.com/http-party/http-server). It is written in Rust and uses [actix](https://github.com/actix/actix-web) as the web framework.
 
 ## Contribution
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ fn parse_canonicalize_dir(s: &OsStr) -> Result<PathBuf, io::Error> {
 }
 
 #[derive(Debug, Parser)]
-#[clap(name = "Mythian")]
+#[clap(name = "Zy")]
 #[clap(about, version, setting = AppSettings::DeriveDisplayOrder)]
 pub struct Args {
     /// Directory to serve

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -6,9 +6,9 @@ use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::header;
 pub use actix_web::middleware::Compress;
 
-pub struct MythianServer;
+pub struct ZyServer;
 
-impl<S, B> Transform<S, ServiceRequest> for MythianServer
+impl<S, B> Transform<S, ServiceRequest> for ZyServer
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>>,
     S::Future: 'static,
@@ -16,20 +16,20 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Transform = MythianServerMiddleware<S>;
+    type Transform = ZyServerMiddleware<S>;
     type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        ready(Ok(MythianServerMiddleware { service }))
+        ready(Ok(ZyServerMiddleware { service }))
     }
 }
 
-pub struct MythianServerMiddleware<S> {
+pub struct ZyServerMiddleware<S> {
     service: S,
 }
 
-impl<S, B> Service<ServiceRequest> for MythianServerMiddleware<S>
+impl<S, B> Service<ServiceRequest> for ZyServerMiddleware<S>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>>,
     S::Future: 'static,
@@ -49,8 +49,10 @@ where
         Box::pin(async move {
             let mut res = fut.await?;
 
-            res.headers_mut()
-                .insert(header::SERVER, header::HeaderValue::from_static("Mythian"));
+            res.headers_mut().insert(
+                header::SERVER,
+                header::HeaderValue::from_static(concat!("Zy/", env!("CARGO_PKG_VERSION"))),
+            );
 
             Ok(res)
         })


### PR DESCRIPTION
`Zy` - Minimal and blazing-fast file server. For real, this time.

```console
$ zy --help
Zy 0.1.0
Minimal and blazing-fast file server.

USAGE:
    zy [OPTIONS] [DIR]

ARGS:
    <DIR>    Directory to serve [default: .]

OPTIONS:
    -l, --listen <URI>    Sets the address to listen on (repeatable)
                          Valid: `3000`, `127.0.0.1`, `127.0.0.1:3000` [default: 127.0.0.1:3000]
    -s, --spa             Run as a Single Page Application
    -i, --index <FILE>    Index file to serve from the base directory [default: index.html]
        --404 <FILE>      404 file to serve from the base directory [default: 404.html]
    -c, --cache <SECS>    Cache time (max-age) in seconds [default: 3600]
        --no-cors         Disable Cross-Origin Resource Sharing (CORS)
    -a, --all             Serve hidden files
    -f, --follow-links    Follow symlinks outside of the base directory (unsafe)
    -v, --verbose         Be verbose
    -x, --confirm-exit    Require confirmation before exiting on Ctrl+C
    -h, --help            Print help information
    -V, --version         Print version information
```