### PR TITLE
add CI release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
   check:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         rust-version: [1.59.0, stable]
         name: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  RUSTFLAGS: -D warnings
+  RUST_BACKTRACE: short
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-version: [1.59.0, stable]
+        name: [
+          # aaarch64
+          linux-aarch64-gnu, macos-aarch64,
+          # arm
+          linux-arm-gnu, linux-arm-musl,
+          # i686
+          win32-msvc, linux-i686-gnu, linux-i686-musl,
+          # x86_64
+          macos-x86_64, win64-gnu, win64-msvc, linux-x86_64-gnu, linux-x86_64-musl
+        ]
+        include:
+        - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
+        - { name: 'macos-aarch64'    , target: aarch64-apple-darwin        , os: macos-latest  ,                 }
+        - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
+        - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
+        - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest , use-cross: true }
+        - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
+        - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
+        - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
+        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest ,                 }
+        - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        case ${{ matrix.target }} in
+          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+        esac
+
+    - name: Install rust
+      uses: dtolnay/rust-toolchain@${{ matrix.rust-version }}
+      with:
+        target: ${{ matrix.target }}
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.target }}
+
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.use-cross }}
+        command: check
+
+    - name: Clippy
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.use-cross }}
+        command: clippy
+        args: -D clippy::all
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Run clippy
+      run: cargo clippy -- -D clippy::all
+
+  cargo-fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Run cargo fmt
+      run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         command: check
 
     - name: Check if clippy is installed
+      shell: bash
       run: |
         rustup component list --installed | grep clippy
         if [ $? -eq 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,36 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.target }}
+        key: ${{ matrix.target }}-${{ matrix.rust-version }}
 
     - name: Check
       uses: actions-rs/cargo@v1
       with:
         use-cross: ${{ matrix.use-cross }}
         command: check
+
+  clippy:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-version: [1.59.0, stable]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust-version }}
+        target: ${{ matrix.target }}
+        components: clippy
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.os }}-${{ matrix.rust-version }}
 
     - name: Check if clippy is installed
       shell: bash
@@ -83,23 +106,12 @@ jobs:
           echo "CLIPPY_INSTALLED=false" >> $GITHUB_ENV
         fi
 
-    - name: Clippy
+    - name: Run cargo clippy
       if: env.CLIPPY_INSTALLED == 'true'
       uses: actions-rs/cargo@v1
       with:
-        use-cross: ${{ matrix.use-cross }}
         command: clippy
         args: -- -D clippy::all
-
-  clippy:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Run clippy
-      run: cargo clippy -- -D clippy::all
 
   cargo-fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,57 +20,25 @@ jobs:
       fail-fast: false
       matrix:
         rust-version: [1.59.0, stable]
-        name: [
-          # aaarch64
-          linux-aarch64-gnu, macos-aarch64,
-          # arm
-          linux-arm-gnu, linux-arm-musl,
-          # i686
-          win32-msvc, linux-i686-gnu, linux-i686-musl,
-          # x86_64
-          macos-x86_64, win64-gnu, win64-msvc, linux-x86_64-gnu, linux-x86_64-musl
-        ]
-        include:
-        - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
-        - { name: 'macos-aarch64'    , target: aarch64-apple-darwin        , os: macos-latest  ,                 }
-        - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
-        - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
-        - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
-        - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest , use-cross: true }
-        - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest , use-cross: true }
-        - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
-        - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
-        - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
-        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest ,                 }
-        - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
-    - name: Install prerequisites
-      shell: bash
-      run: |
-        case ${{ matrix.target }} in
-          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
-          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
-        esac
 
     - name: Install rust
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust-version }}
         target: ${{ matrix.target }}
-        components: clippy
 
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.target }}-${{ matrix.rust-version }}
+        key: ${{ matrix.os }}-${{ matrix.rust-version }}
 
-    - name: Check
+    - name: Run cargo check
       uses: actions-rs/cargo@v1
       with:
-        use-cross: ${{ matrix.use-cross }}
         command: check
 
   clippy:
@@ -113,7 +81,7 @@ jobs:
         command: clippy
         args: -- -D clippy::all
 
-  cargo-fmt:
+  fmt:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       with:
         use-cross: ${{ matrix.use-cross }}
         command: clippy
-        args: -D clippy::all
+        args: -- -D clippy::all
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   check:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         rust-version: [1.59.0, stable]
         name: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-version }}
         target: ${{ matrix.target }}
+        components: clippy
 
     - uses: Swatinem/rust-cache@v2
       with:
@@ -72,7 +73,17 @@ jobs:
         use-cross: ${{ matrix.use-cross }}
         command: check
 
+    - name: Check if clippy is installed
+      run: |
+        rustup component list --installed | grep clippy
+        if [ $? -eq 0 ]; then
+          echo "CLIPPY_INSTALLED=true" >> $GITHUB_ENV
+        else
+          echo "CLIPPY_INSTALLED=false" >> $GITHUB_ENV
+        fi
+
     - name: Clippy
+      if: env.CLIPPY_INSTALLED == 'true'
       uses: actions-rs/cargo@v1
       with:
         use-cross: ${{ matrix.use-cross }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -57,8 +57,9 @@ jobs:
         esac
 
     - name: Install rust
-      uses: dtolnay/rust-toolchain@${{ matrix.rust-version }}
+      uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: ${{ matrix.rust-version }}
         target: ${{ matrix.target }}
 
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,12 @@ jobs:
     - name: Get Project Name
       run: |
         PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)
+        echo "Project Name: $PROJECT_NAME"
 
         if [[ "${PROJECT_INDEX_URL}" == *"${PROJECT_NAME}" ]]; then
           echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
         else
-          echo "Project name [${PROJECT_NAME}] does not match the index URL [${PROJECT_INDEX_URL}]."
+          echo "Project name does not match the index URL [${PROJECT_INDEX_URL}]."
           exit 1
         fi
 
@@ -61,7 +62,7 @@ jobs:
         echo "Project version: ${PROJECT_VERSION}"
 
         CRATE_VERSIONS=$(curl -s "${PROJECT_INDEX_URL}" | jq -r '.vers')
-        echo "Crate versions: ${CRATE_VERSIONS}"
+        echo "Already published versions:\n${CRATE_VERSIONS}"
         if echo "${CRATE_VERSIONS}" | grep -q "^${PROJECT_VERSION}$"; then
           echo "Project version [${PROJECT_VERSION}] has already been released."
           HAS_RELEASED=true
@@ -71,8 +72,10 @@ jobs:
         fi
 
         if [[ "${PROJECT_VERSION}" == *-* ]]; then
+          echo "Project version [${PROJECT_VERSION}] is a pre-release."
           IS_PRERELEASE=true
         else
+          echo "Project version [${PROJECT_VERSION}] is not a pre-release."
           IS_PRERELEASE=false
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   binary:
-    # name: binary (${{ matrix.job.name }})
-    runs-on: ${{ matrix.job.os }}
+    runs-on: ${{ matrix.os }}
     needs: check
     # if: needs.check.outputs.should_release_binary == 'true'
     env:
@@ -151,23 +150,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job:
-          - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
-          - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
-          - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
-          - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
-          - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest , use-cross: true }
-          - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest , use-cross: true }
-          - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
-          - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
-          - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
-          - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest , use-cross: true }
-          - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
+        name: [
+          # aaarch64
+          linux-aarch64-gnu,
+          # arm
+          linux-arm-gnu, linux-arm-musl,
+          # i686
+          win32-msvc, linux-i686-gnu, linux-i686-musl,
+          # x86_64
+          macos-x86_64, win64-gnu, win64-msvc, linux-x86_64-gnu, linux-x86_64-musl
+        ]
+        include:
+        - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
+        - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
+        - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest , use-cross: true }
+        - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
+        - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
+        - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
+        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
-    - shell: bash
-      run: echo "::job-name::binary (${{ matrix.job.name }})"
-
     - shell: bash
       run: exit 1
 
@@ -177,7 +183,7 @@ jobs:
     - name: Install prerequisites
       shell: bash
       run: |
-        case ${{ matrix.job.target }} in
+        case ${{ matrix.target }} in
           arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
           aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
         esac
@@ -185,32 +191,32 @@ jobs:
     - name: Install rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        target: ${{ matrix.job.target }}
+        target: ${{ matrix.target }}
 
     - name: Build
       uses: actions-rs/cargo@v1
       with:
-        use-cross: ${{ matrix.job.use-cross }}
+        use-cross: ${{ matrix.use-cross }}
         command: build
-        args: --verbose --locked --profile ci-build --target=${{ matrix.job.target }}
+        args: --verbose --locked --profile ci-build --target=${{ matrix.target }}
 
     - name: Strip debug information from executable
       id: strip
       shell: bash
       run: |
         EXE_suffix=""
-        case ${{ matrix.job.target }} in
+        case ${{ matrix.target }} in
           *-pc-windows-*) EXE_suffix=".exe" ;;
         esac
 
         STRIP="strip"
-        case ${{ matrix.job.target }} in
+        case ${{ matrix.target }} in
           arm-unknown-linux-*) STRIP="arm-linux-gnueabihf-strip" ;;
           aarch64-unknown-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;;
           *-pc-windows-msvc) STRIP="" ;;
         esac
 
-        PROJECT_BIN_PATH="target/${{ matrix.job.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
+        PROJECT_BIN_PATH="target/${{ matrix.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
 
         if [ -n "${STRIP}" ]; then
           "${STRIP}" "${PROJECT_BIN_PATH}"
@@ -221,13 +227,13 @@ jobs:
     - name: Build archive
       shell: bash
       run: |
-        PKG_BASENAME="${{ env.PROJECT_NAME }}-${{ env.PROJECT_VERSION }}-${{ matrix.job.target }}"
+        PKG_BASENAME="${{ env.PROJECT_NAME }}-${{ env.PROJECT_VERSION }}-${{ matrix.target }}"
         mkdir "${PKG_BASENAME}"
 
         cp "${PROJECT_BIN_PATH}" "${PKG_BASENAME}/"
         cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "${PKG_BASENAME}/"
 
-        case ${{ matrix.job.target }} in
+        case ${{ matrix.target }} in
           *-pc-windows-*)
               PKG_PATH="${PKG_BASENAME}.zip"
               7z -y a "${PKG_PATH}" "${PKG_BASENAME}"/* | tail -2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
         tag_name: ${{ env.ZY_VERSION }}
         files: ${{ env.ZY_PKG_PATH }}
         token: ${{ secrets.GITHUB_TOKEN }}
+        target_commitish: ${{ github.sha }}
         body: |
           ## What's changed?
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,11 +136,12 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   binary:
-    name: binary (${{ matrix.job.name }})
+    name: ${{ env.STEP_NAME }}
     runs-on: ${{ matrix.job.os }}
     needs: check
     if: needs.check.outputs.should_release_binary == 'true'
     env:
+      STEP_NAME: binary
       PROJECT_NAME: ${{ needs.check.outputs.project_name }}
       PROJECT_VERSION: v${{ needs.check.outputs.project_version }}
       RAW_PROJECT_VERSION: ${{ needs.check.outputs.project_version }}
@@ -164,6 +165,10 @@ jobs:
           - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
+    - name: Update step name
+      run: |
+        echo "STEP_NAME=binary (${{ matrix.job.name }})" >> $GITHUB_ENV
+
     - name: Checkout repository
       uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |
+        gh --version
         DEFAULT_RELEASE_NOTE="$(
           gh api \
             /repos/${{ github.repository }}/releases/generate-notes \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       is_prerelease: ${{ env.IS_PRERELEASE }}
       has_released: ${{ env.HAS_RELEASED }}
       publish_crate: ${{ env.HAS_RELEASED == 'false' && github.event_name != 'workflow_dispatch' }}
+      git_previous_tag: ${{ env.GIT_PREVIOUS_TAG }}
     env:
       HAS_RELEASED: false
       PROJECT_VERSION: ${{ github.event.inputs.project-version }}
@@ -43,8 +44,18 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        # might be a simple `fetch-tags: true` option soon, see https://github.com/actions/checkout/pull/579
+        fetch-depth: 0
 
-    - name: Get Project Name
+    - name: Check git environment
+      shell: bash
+      run: |
+        GIT_PREVIOUS_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')"
+        echo "GIT_PREVIOUS_TAG=${GIT_PREVIOUS_TAG}" >> $GITHUB_ENV
+        echo "Current latest git release tag is \"${GIT_PREVIOUS_TAG}\""
+
+    - name: Get project name
       run: |
         PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)
         echo "Project Name: $PROJECT_NAME"
@@ -56,7 +67,7 @@ jobs:
           exit 1
         fi
 
-    - name: Version Introspection
+    - name: Version introspection
       if: env.PROJECT_VERSION == ''
       run: |
         PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
@@ -114,6 +125,7 @@ jobs:
       IS_PRERELEASE: ${{ needs.check.outputs.is_prerelease }}
       HAS_RELEASED: ${{ needs.check.outputs.has_released }}
       PUBLISH_CRATE: ${{ needs.check.outputs.publish_crate }}
+      GIT_PREVIOUS_TAG: ${{ needs.check.outputs.git_previous_tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -133,9 +145,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        # might be a simple `fetch-tags: true` option soon, see https://github.com/actions/checkout/pull/579
-        fetch-depth: 0
 
     - name: Install prerequisites
       shell: bash
@@ -161,13 +170,11 @@ jobs:
       id: strip
       shell: bash
       run: |
-        # Figure out suffix of binary
         EXE_suffix=""
         case ${{ matrix.job.target }} in
           *-pc-windows-*) EXE_suffix=".exe" ;;
         esac
 
-        # Figure out what strip tool to use if any
         STRIP="strip"
         case ${{ matrix.job.target }} in
           arm-unknown-linux-*) STRIP="arm-linux-gnueabihf-strip" ;;
@@ -241,13 +248,9 @@ jobs:
         echo
         echo "PRETTY_CONTRIBUTOR_LIST=${PRETTY_CONTRIBUTOR_LIST}" >> $GITHUB_ENV
 
-    - name: Check current latest tag
+    - name: Prepare release body
       shell: bash
       run: |
-        export GIT_PREVIOUS_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')"
-        echo "GIT_PREVIOUS_TAG=${GIT_PREVIOUS_TAG}" >> $GITHUB_ENV
-        echo "Current latest git release tag is \"${GIT_PREVIOUS_TAG}\""
-
         if [ -n "${PRETTY_CONTRIBUTOR_LIST}" ]; then
           PRETTY_CONTRIBUTOR_LINE=" \
             <sup> \
@@ -257,11 +260,13 @@ jobs:
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 
-        # if PUBLISH_CRATE is set to true, then we will publish the crate to crates.io
         if [[ "${{ env.PUBLISH_CRATE }}" == "true" ]]; then
           CRATE_LINE="**Crate Link**: https://crates.io/crates/${{ env.PROJECT_NAME }}/${{ env.RAW_PROJECT_VERSION }}"
           echo "CRATE_LINE=${CRATE_LINE}" >> $GITHUB_ENV
         fi
+
+        CHANGELOG_LINE="**Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.PROJECT_VERSION }}"
+        echo "CHANGELOG_LINE=${CHANGELOG_LINE}" >> $GITHUB_ENV
 
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
@@ -278,6 +283,6 @@ jobs:
 
           ${{ env.CRATE_LINE }}
 
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.PROJECT_VERSION }}
+          ${{ env.CHANGELOG_LINE }}
 
           ${{ env.PRETTY_CONTRIBUTOR_LINE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.job.os }}
     strategy:
+      fail-fast: false
       matrix:
         job:
           - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
@@ -57,8 +58,8 @@ jobs:
       shell: bash
       run: |
         case ${{ matrix.job.target }} in
-          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y gcc-arm-linux-gnueabihf ;;
-          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y gcc-aarch64-linux-gnu ;;
+          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
         esac
 
     - name: Install Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,8 @@ jobs:
         DEFAULT_RELEASE_NOTE="$(
           gh api \
             /repos/${{ github.repository }}/releases/generate-notes \
-            -f tag_name='${{ github.sha }}' \
+            -f tag_name='${{ env.ZY_VERSION }}' \
+            -f target_commitish='${{ github.sha }}' \
             -q .body \
         )"
         echo "Default Release Note"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,22 +8,82 @@ name: release
 
 on:
   push:
-    # Enable when testing release infrastructure on a branch.
     branches:
+    # - master
     - ci/release-check
-    tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
-    - "v[0-9]+.[0-9]+.[0-9]+-*"
+  workflow_dispatch:
+    inputs:
+      project-version:
+        description: 'Version to release on GitHub'
+        required: true
+        type: string
+      is-pre-release:
+        description: 'Is this a pre-release?'
+        required: true
+        type: boolean
 
 env:
-  # Emit backtraces on panics.
-  RUST_BACKTRACE: 1
-  # Set to force version number, e.g., when no tag exists.
-  ZY_VERSION: v0.1.6
+  PROJECT_INDEX_URL: https://raw.githubusercontent.com/rust-lang/crates.io-index/master/2/zy
+  RUST_BACKTRACE: 1 # Emit backtraces on panics.
     
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      project_name: ${{ env.PROJECT_NAME }}
+      project_version: ${{ env.PROJECT_VERSION }}
+      is_prerelease: ${{ env.IS_PRERELEASE }}
+      has_released: ${{ env.HAS_RELEASED }}
+    env:
+      HAS_RELEASED: false
+      PROJECT_VERSION: ${{ github.event.inputs.project-version }}
+      IS_PRERELEASE: ${{ github.event.inputs.is-pre-release }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Get Project Name
+      run: |
+        PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)
+
+        if [[ "${PROJECT_INDEX_URL}" == *"${PROJECT_NAME}" ]]; then
+          echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
+        else
+          echo "Project name [${PROJECT_NAME}] does not match the index URL [${PROJECT_INDEX_URL}]."
+          exit 1
+        fi
+
+    - name: Version Introspection
+      if: env.PROJECT_VERSION == ''
+      run: |
+        PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
+        echo "Project version: ${PROJECT_VERSION}"
+
+        CRATE_VERSIONS=$(curl -s "${PROJECT_INDEX_URL}" | jq -r '.vers')
+        echo "Crate versions: ${CRATE_VERSIONS}"
+        if echo "${CRATE_VERSIONS}" | grep -q "^${PROJECT_VERSION}$"; then
+          echo "Project version [${PROJECT_VERSION}] has already been released."
+          HAS_RELEASED=true
+        else
+          echo "Project version [${PROJECT_VERSION}] has not been released."
+          HAS_RELEASED=false
+        fi
+
+        if [[ "${PROJECT_VERSION}" == *-* ]]; then
+          IS_PRERELEASE=true
+        else
+          IS_PRERELEASE=false
+        fi
+
+        echo "PROJECT_VERSION=v${PROJECT_VERSION}" >> $GITHUB_ENV
+        echo "IS_PRERELEASE=${IS_PRERELEASE}" >> $GITHUB_ENV
+        echo "HAS_RELEASED=${HAS_RELEASED}" >> $GITHUB_ENV
+
   crate:
     runs-on: ubuntu-latest
+    needs: check
+    if: ${{ needs.check.outputs.has_released }} == 'false' && ${{ github.event_name }} != 'workflow_dispatch'
 
     steps:
     - name: Checkout repository
@@ -42,6 +102,12 @@ jobs:
   binary:
     name: binary (${{ matrix.job.name }})
     runs-on: ${{ matrix.job.os }}
+    needs: check
+    env:
+      PROJECT_NAME: ${{ needs.check.outputs.project_name }}
+      PROJECT_VERSION: ${{ needs.check.outputs.project_version }}
+      IS_PRERELEASE: ${{ needs.check.outputs.is_prerelease }}
+      HAS_RELEASED: ${{ needs.check.outputs.has_released }}
     strategy:
       fail-fast: false
       matrix:
@@ -59,16 +125,6 @@ jobs:
           - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
-    - name: Get the release version from the tag
-      shell: bash
-      if: env.ZY_VERSION == ''
-      run: |
-        # Apparently, this is the right way to get a tag name. Really?
-        #
-        # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-        echo "ZY_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-        echo "version is: ${{ env.ZY_VERSION }}"
-
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
@@ -113,35 +169,34 @@ jobs:
           *-pc-windows-msvc) STRIP="" ;;
         esac
         
-        ZY_BIN_PATH="target/${{ matrix.job.target }}/ci-build/zy${EXE_suffix}"
+        PROJECT_BIN_PATH="target/${{ matrix.job.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
         
         if [ -n "${STRIP}" ]; then
-          "${STRIP}" "${ZY_BIN_PATH}"
+          "${STRIP}" "${PROJECT_BIN_PATH}"
         fi
 
-        echo "ZY_BIN_PATH=${ZY_BIN_PATH}" >> $GITHUB_ENV
+        echo "PROJECT_BIN_PATH=${PROJECT_BIN_PATH}" >> $GITHUB_ENV
 
     - name: Build archive
       shell: bash
       run: |
-        # zy-v0.1.4-x86_64-unknown-linux-gnu
-        ZY_PKG_BASENAME="zy-${{ env.ZY_VERSION }}-${{ matrix.job.target }}"
-        mkdir "${ZY_PKG_BASENAME}"
+        PKG_BASENAME="${{ env.PROJECT_NAME }}-${{ env.PROJECT_VERSION }}-${{ matrix.job.target }}"
+        mkdir "${PKG_BASENAME}"
 
-        cp "${ZY_BIN_PATH}" "${ZY_PKG_BASENAME}/"
-        cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "${ZY_PKG_BASENAME}/"
+        cp "${PROJECT_BIN_PATH}" "${PKG_BASENAME}/"
+        cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "${PKG_BASENAME}/"
 
         case ${{ matrix.job.target }} in
           *-pc-windows-*)
-              ZY_PKG_PATH="${ZY_PKG_BASENAME}.zip"
-              7z -y a "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}"/* | tail -2
+              PKG_PATH="${PKG_BASENAME}.zip"
+              7z -y a "${PKG_PATH}" "${PKG_BASENAME}"/* | tail -2
             ;;
           *)
-              ZY_PKG_PATH="${ZY_PKG_BASENAME}.tar.gz"
-              tar czf "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}"/*
+              PKG_PATH="${PKG_BASENAME}.tar.gz"
+              tar czf "${PKG_PATH}" "${PKG_BASENAME}"/*
             ;;
         esac
-        echo "ZY_PKG_PATH=${ZY_PKG_PATH}" >> $GITHUB_ENV
+        echo "PKG_PATH=${PKG_PATH}" >> $GITHUB_ENV
 
     - name: Extract release notes
       id: extract-release-notes
@@ -155,9 +210,9 @@ jobs:
       run: |
         DEFAULT_RELEASE_NOTE="$(
           curl -v \
-            https://api.github.com/repos/miraclx/zy/releases/generate-notes \
+            https://api.github.com/repos/${{ github.repository }}/releases/generate-notes \
             -H 'Authorization: token ${{ github.token }}' \
-            -d '{"tag_name":"${{ env.ZY_VERSION }}","target_commitish":"${{ github.sha }}"}' \
+            -d '{"tag_name":"${{ env.PROJECT_VERSION }}","target_commitish":"${{ github.sha }}"}' \
           | jq .body
         )"
         echo "Default Release Note"
@@ -199,15 +254,16 @@ jobs:
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ env.ZY_VERSION }}
-        files: ${{ env.ZY_PKG_PATH }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: ${{ env.PROJECT_VERSION }}
+        prerelease: ${{ env.IS_PRERELEASE }}
         target_commitish: ${{ github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: ${{ env.PKG_PATH }}
         body: |
           ## What's changed?
         
           ${{ steps.extract-release-notes.outputs.release_notes }}
 
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.ZY_VERSION }}
+          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.PROJECT_VERSION }}
 
           ${{ env.PRETTY_CONTRIBUTOR_LINE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,7 @@ jobs:
     - name: Prepare release body
       shell: bash
       run: |
+        PRETTY_CONTRIBUTOR_LIST="@bulan-ci, @iTranscend and @miraclx"
         if [ -n "${PRETTY_CONTRIBUTOR_LIST}" ]; then
           PRETTY_CONTRIBUTOR_LINE=" \
             <sup> \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ name: release
 on:
   push:
     branches:
-    # - master
-    - ci/release-check
+    - master
   workflow_dispatch:
     inputs:
       project-version:
@@ -133,7 +132,6 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: publish
-        args: --dry-run
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,21 +22,22 @@ env:
     
 jobs:
   build-release:
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.job.os }}
     strategy:
       matrix:
         job:
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
-          - { target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
-          - { target: i686-pc-windows-msvc        , os: windows-2019                  }
-          - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
-          - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-10.15                   }
-          - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
+          - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
+          - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
+          - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
+          - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-2019                  }
+          - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
+          - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
+          - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-10.15                   }
+          - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-2019                  }
+          - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-2019                  }
+          - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
+          - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
 
     steps:
     - name: Get the release version from the tag
@@ -61,10 +62,9 @@ jobs:
         esac
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: ${{ matrix.rust }}
-        target: ${{ matrix.target }}
+        target: ${{ matrix.job.target }}
 
     - name: Build
       uses: actions-rs/cargo@v1
@@ -103,7 +103,7 @@ jobs:
       shell: bash
       run: |
         # zy-v0.1.4-x86_64-unknown-linux-gnu
-        ZY_PKG_BASENAME="zy-${{ env.ZY_VERSION }}-${{ matrix.target }}"
+        ZY_PKG_BASENAME="zy-${{ env.ZY_VERSION }}-${{ matrix.job.target }}"
         mkdir "$ZY_PKG_BASENAME"
 
         cp "${ZY_BIN_PATH}" "$ZY_PKG_BASENAME/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
       RAW_PROJECT_VERSION: ${{ needs.check.outputs.project_version }}
       IS_PRERELEASE: ${{ needs.check.outputs.is_prerelease }}
       GIT_PREVIOUS_TAG: ${{ needs.check.outputs.git_previous_tag }}
-      SHOULD_PUBLISH_CRATE: ${{ needs.check.outputs.should_publish_crate }}
+      WILL_PUBLISH_CRATE: ${{ needs.check.outputs.should_publish_crate }}
     strategy:
       fail-fast: false
       matrix:
@@ -276,7 +276,7 @@ jobs:
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 
-        if [[ "${{ env.SHOULD_PUBLISH_CRATE }}" == "true" ]]; then
+        if [[ "${{ env.WILL_PUBLISH_CRATE }}" == "true" ]]; then
           CRATE_LINE="**Crate Link**: https://crates.io/crates/${{ env.PROJECT_NAME }}/${{ env.RAW_PROJECT_VERSION }}"
           echo "CRATE_LINE=${CRATE_LINE}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
       id: get-contributors
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
       run: |
         DEFAULT_RELEASE_NOTE="$(
           gh api \
@@ -162,6 +163,7 @@ jobs:
         echo "PRETTY_CONTRIBUTOR_LIST=${PRETTY_CONTRIBUTOR_LIST}" >> $GITHUB_ENV
 
     - name: Check Current Latest Tag
+      shell: bash
       run: |
         export GIT_PREVIOUS_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')"
         echo "GIT_PREVIOUS_TAG=${GIT_PREVIOUS_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ env:
     
 jobs:
   build-release:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.job.name }}
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,11 @@ jobs:
       project_name: ${{ env.PROJECT_NAME }}
       project_version: ${{ env.PROJECT_VERSION }}
       is_prerelease: ${{ env.IS_PRERELEASE }}
-      has_released: ${{ env.HAS_RELEASED }}
-      publish_crate: ${{ env.HAS_RELEASED == 'false' && github.event_name != 'workflow_dispatch' }}
+      has_released_crate: ${{ env.HAS_RELEASED_CRATE }}
+      should_publish_crate: ${{ env.HAS_RELEASED_CRATE == 'false' && github.event_name != 'workflow_dispatch' }}
       git_previous_tag: ${{ env.GIT_PREVIOUS_TAG }}
     env:
-      HAS_RELEASED: false
+      HAS_RELEASED_CRATE: false
       PROJECT_VERSION: ${{ github.event.inputs.project-version }}
       IS_PRERELEASE: ${{ github.event.inputs.is-pre-release }}
 
@@ -77,10 +77,10 @@ jobs:
         echo "Already published versions:\n${CRATE_VERSIONS}"
         if echo "${CRATE_VERSIONS}" | grep -q "^${PROJECT_VERSION}$"; then
           echo "Project version [${PROJECT_VERSION}] has already been released."
-          HAS_RELEASED=true
+          HAS_RELEASED_CRATE=true
         else
           echo "Project version [${PROJECT_VERSION}] has not been released."
-          HAS_RELEASED=false
+          HAS_RELEASED_CRATE=false
         fi
 
         if [[ "${PROJECT_VERSION}" == *-* ]]; then
@@ -92,13 +92,13 @@ jobs:
         fi
 
         echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
+        echo "HAS_RELEASED_CRATE=${HAS_RELEASED_CRATE}" >> $GITHUB_ENV
         echo "IS_PRERELEASE=${IS_PRERELEASE}" >> $GITHUB_ENV
-        echo "HAS_RELEASED=${HAS_RELEASED}" >> $GITHUB_ENV
 
   crate:
     runs-on: ubuntu-latest
     needs: check
-    if: needs.check.outputs.publish_crate == 'true'
+    if: needs.check.outputs.should_publish_crate == 'true'
 
     steps:
     - name: Checkout repository
@@ -123,8 +123,8 @@ jobs:
       PROJECT_VERSION: v${{ needs.check.outputs.project_version }}
       RAW_PROJECT_VERSION: ${{ needs.check.outputs.project_version }}
       IS_PRERELEASE: ${{ needs.check.outputs.is_prerelease }}
-      HAS_RELEASED: ${{ needs.check.outputs.has_released }}
-      PUBLISH_CRATE: ${{ needs.check.outputs.publish_crate }}
+      HAS_RELEASED_CRATE: ${{ needs.check.outputs.has_released_crate }}
+      SHOULD_PUBLISH_CRATE: ${{ needs.check.outputs.should_publish_crate }}
       GIT_PREVIOUS_TAG: ${{ needs.check.outputs.git_previous_tag }}
     strategy:
       fail-fast: false
@@ -260,7 +260,7 @@ jobs:
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 
-        if [[ "${{ env.PUBLISH_CRATE }}" == "true" ]]; then
+        if [[ "${{ env.SHOULD_PUBLISH_CRATE }}" == "true" ]]; then
           CRATE_LINE="**Crate Link**: https://crates.io/crates/${{ env.PROJECT_NAME }}/${{ env.RAW_PROJECT_VERSION }}"
           echo "CRATE_LINE=${CRATE_LINE}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
       run: |
         PRETTY_CONTRIBUTOR_LIST="@bulan-ci, @iTranscend and @miraclx"
         if [ -n "${PRETTY_CONTRIBUTOR_LIST}" ]; then
-          PRETTY_CONTRIBUTOR_LINE="<sup> 🎉  Thanks to ${{ env.PRETTY_CONTRIBUTOR_LIST }} for their contributions to this release. 🎉 </sup>"
+          PRETTY_CONTRIBUTOR_LINE="<sup> 🎉  Thanks to ${PRETTY_CONTRIBUTOR_LIST} for their contributions to this release. 🎉 </sup>"
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,25 @@ env:
   ZY_VERSION: v0.1.5
     
 jobs:
-  build-release:
-    name: ${{ matrix.job.name }}
+  crate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - uses: actions-rs/cargo@v1
+      with:
+        command: publish
+        args: --dry-run
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  binary:
+    name: binary (${{ matrix.job.name }})
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,15 @@ jobs:
         echo "GIT_PREVIOUS_TAG=${GIT_PREVIOUS_TAG}" >> $GITHUB_ENV
         echo "Current latest git release tag is \"${GIT_PREVIOUS_TAG}\""
 
+        if [ -n "${PRETTY_CONTRIBUTOR_LIST}" ]; then
+          PRETTY_CONTRIBUTOR_LINE=" \
+            <sup> \
+              🎉  Thanks to ${{ env.PRETTY_CONTRIBUTOR_LIST }} for their contributions to this release. 🎉 \
+            </sup> \
+          "
+          echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
+        fi
+
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
       with:
@@ -181,6 +190,5 @@ jobs:
           ${{ steps.extract-release-notes.outputs.release_notes }}
 
           **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.ZY_VERSION }}
-          <sup>
-          🎉  Thanks to ${{ env.PRETTY_CONTRIBUTOR_LIST }} for their contributions to this release. 🎉
-          </sup>
+
+          ${{ env.PRETTY_CONTRIBUTOR_LINE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
       matrix:
         name: [
           # aaarch64
-          linux-aarch64-gnu,
+          linux-aarch64-gnu, macos-aarch64,
           # arm
           linux-arm-gnu, linux-arm-musl,
           # i686
@@ -162,6 +162,7 @@ jobs:
         ]
         include:
         - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
+        - { name: 'macos-aarch64'    , target: aarch64-apple-darwin        , os: macos-latest  ,                 }
         - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
         - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
         - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
@@ -189,6 +190,10 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ matrix.target }}
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.target }}
 
     - name: Build
       uses: actions-rs/cargo@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       with:
         use-cross: ${{ matrix.job.use-cross }}
         command: build
-        args: --verbose --locked --release --target=${{ matrix.job.target }}
+        args: --verbose --locked --profile ci-build --target=${{ matrix.job.target }}
 
     - name: Strip debug information from executable
       id: strip
@@ -103,7 +103,7 @@ jobs:
         EXE_suffix=""
         case ${{ matrix.job.target }} in
           *-pc-windows-*) EXE_suffix=".exe" ;;
-        esac;
+        esac
 
         # Figure out what strip tool to use if any
         STRIP="strip"
@@ -111,7 +111,7 @@ jobs:
           arm-unknown-linux-*) STRIP="arm-linux-gnueabihf-strip" ;;
           aarch64-unknown-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;;
           *-pc-windows-msvc) STRIP="" ;;
-        esac;
+        esac
         
         ZY_BIN_PATH="target/${{ matrix.job.target }}/release/zy${EXE_suffix}"
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
         files: ${{ env.ZY_PKG_PATH }}
         token: ${{ secrets.GITHUB_TOKEN }}
         body: |
-          ## What's changed in ${{ matrix.job.target }}?
+          ## What's changed?
         
           ${{ steps.extract-release-notes.outputs.release_notes }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   binary:
-    name: binary (${{ matrix.job.name || "" }})
+    # name: binary (${{ matrix.job.name }})
     runs-on: ${{ matrix.job.os }}
     needs: check
     if: needs.check.outputs.should_release_binary == 'true'
@@ -165,6 +165,9 @@ jobs:
           - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
+    - shell: bash
+      run: echo "::job-name::binary (${{ matrix.job.name }})"
+
     - name: Checkout repository
       uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,11 +155,11 @@ jobs:
       run: |
         gh --version
         DEFAULT_RELEASE_NOTE="$(
-          gh api \
-            /repos/${{ github.repository }}/releases/generate-notes \
-            -f tag_name='${{ env.ZY_VERSION }}' \
-            -f target_commitish='${{ github.sha }}' \
-            -q .body \
+          curl -v \
+            https://api.github.com/repos/miraclx/zy/releases/generate-notes \
+            -H 'Authorization: token ${{ github.token }}' \
+            -d '{"tag_name":"${{ env.ZY_VERSION }}","target_commitish":"${{ github.sha }}"}' \
+          | jq .body
         )"
         echo "Default Release Note"
         echo "${DEFAULT_RELEASE_NOTE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   binary:
-    name: ${{ env.STEP_NAME }}
+    name: binary (${{ matrix.job.name || "" }})
     runs-on: ${{ matrix.job.os }}
     needs: check
     if: needs.check.outputs.should_release_binary == 'true'
@@ -165,10 +165,6 @@ jobs:
           - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
-    - name: Update step name
-      run: |
-        echo "STEP_NAME=binary (${{ matrix.job.name }})" >> $GITHUB_ENV
-
     - name: Checkout repository
       uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   # Emit backtraces on panics.
   RUST_BACKTRACE: 1
   # Set to force version number, e.g., when no tag exists.
-  ZY_VERSION: v0.1.5
+  ZY_VERSION: v0.1.6
     
 jobs:
   crate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
         - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
         - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
         - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
-        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest                   }
+        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest ,                 }
         - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
         esac
 
-    - name: Install Rust
+    - name: Install rust
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ matrix.job.target }}
@@ -130,7 +130,7 @@ jobs:
       id: extract-release-notes
       uses: ffurrer2/extract-release-notes@c24866884b7a0d2fd2095be2e406b6f260479da8
 
-    - name: Get Contributors
+    - name: Get contributors
       id: get-contributors
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
         echo
         echo "PRETTY_CONTRIBUTOR_LIST=${PRETTY_CONTRIBUTOR_LIST}" >> $GITHUB_ENV
 
-    - name: Check Current Latest Tag
+    - name: Check current latest tag
       shell: bash
       run: |
         export GIT_PREVIOUS_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
     env:
       PROJECT_NAME: ${{ needs.check.outputs.project_name }}
       PROJECT_VERSION: v${{ needs.check.outputs.project_version }}
-      RAW_PROJECT_VERSION: ${{ needs.check.outputs.raw_project_version }}
+      RAW_PROJECT_VERSION: ${{ needs.check.outputs.project_version }}
       IS_PRERELEASE: ${{ needs.check.outputs.is_prerelease }}
       HAS_RELEASED: ${{ needs.check.outputs.has_released }}
       PUBLISH_CRATE: ${{ needs.check.outputs.publish_crate }}
@@ -257,7 +257,8 @@ jobs:
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 
-        if [ "${{ env.PUBLISH_CRATE }}" = "true" ]; then
+        # if PUBLISH_CRATE is set to true, then we will publish the crate to crates.io
+        if [[ "${{ env.PUBLISH_CRATE }}" == "true" ]]; then
           CRATE_LINE="**Crate Link**: https://crates.io/crates/${{ env.PROJECT_NAME }}/${{ env.RAW_PROJECT_VERSION }}"
           echo "CRATE_LINE=${CRATE_LINE}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,18 +161,18 @@ jobs:
           macos-x86_64, win64-gnu, win64-msvc, linux-x86_64-gnu, linux-x86_64-musl
         ]
         include:
-        - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  }
         - { name: 'macos-aarch64'    , target: aarch64-apple-darwin        , os: macos-latest  ,                 }
-        - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
-        - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest  }
+        - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest  }
         - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
-        - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest , use-cross: true }
-        - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest  }
+        - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest  }
         - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
         - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
         - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
-        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest , use-cross: true }
-        - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest  }
+        - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest  }
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
     branches:
     - ci/release-check
     tags:
-    - "[0-9]+.[0-9]+.[0-9]+"
-    - "[0-9]+.[0-9]+.[0-9]+-*"
+    - "v[0-9]+.[0-9]+.[0-9]+"
+    - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 env:
   # Emit backtraces on panics.
@@ -125,5 +125,6 @@ jobs:
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
       with:
+        tag_name: ${{ env.ZY_VERSION }}
         files: ${{ env.ZY_PKG_PATH }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
         DEFAULT_RELEASE_NOTE="$(
           gh api \
             /repos/${{ github.repository }}/releases/generate-notes \
-            -f tag_name='${{ env.ZY_VERSION }}' \
+            -f tag_name='${{ github.sha }}' \
             -q .body \
         )"
         echo "Default Release Note"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         mkdir "$ZY_PKG_BASENAME"
 
         cp "${ZY_BIN_PATH}" "$ZY_PKG_BASENAME/"
-        cp README.md LICENSE-MIT LICENSE-APACHE "$ZY_PKG_BASENAME/"
+        cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "$ZY_PKG_BASENAME/"
 
         case ${{ matrix.job.target }} in
           *-pc-windows-*)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+# Derived from:
+#  - https://github.com/BurntSushi/ripgrep/blob/000015791742bb1280f1853adb714fdee1ba9f8e/.github/workflows/release.yml
+#  - https://github.com/near/near-cli-rs/blob/a8679a3603015f1d651f874fdf0feff0d7514131/.github/workflows/release.yml
+#  - https://github.com/sharkdp/bat/blob/7c847d84b0c3c97df6badfbb39d153ad93aec74e/.github/workflows/CICD.yml
+
+name: release
+
+on:
+  push:
+    # Enable when testing release infrastructure on a branch.
+    branches:
+    - ci/release-check
+    tags:
+    - "[0-9]+.[0-9]+.[0-9]+"
+    - "[0-9]+.[0-9]+.[0-9]+-*"
+
+env:
+  # Emit backtraces on panics.
+  RUST_BACKTRACE: 1
+  # Set to force version number, e.g., when no tag exists.
+  ZY_VERSION: TEST-0.0.0
+    
+jobs:
+  build-release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        job:
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
+          - { target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
+          - { target: i686-pc-windows-msvc        , os: windows-2019                  }
+          - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
+          - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-10.15                   }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
+
+    steps:
+    - name: Get the release version from the tag
+      shell: bash
+      if: env.ZY_VERSION == ''
+      run: |
+        # Apparently, this is the right way to get a tag name. Really?
+        #
+        # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+        echo "ZY_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        echo "version is: ${{ env.ZY_VERSION }}"
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        case ${{ matrix.job.target }} in
+          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y gcc-arm-linux-gnueabihf ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y gcc-aarch64-linux-gnu ;;
+        esac
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+        target: ${{ matrix.target }}
+
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.job.use-cross }}
+        command: build
+        args: --verbose --locked --release --target=${{ matrix.job.target }}
+
+    - name: Strip debug information from executable
+      id: strip
+      shell: bash
+      run: |
+        # Figure out suffix of binary
+        EXE_suffix=""
+        case ${{ matrix.job.target }} in
+          *-pc-windows-*) EXE_suffix=".exe" ;;
+        esac;
+
+        # Figure out what strip tool to use if any
+        STRIP="strip"
+        case ${{ matrix.job.target }} in
+          arm-unknown-linux-*) STRIP="arm-linux-gnueabihf-strip" ;;
+          aarch64-unknown-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;;
+          *-pc-windows-msvc) STRIP="" ;;
+        esac;
+        
+        ZY_BIN_PATH="target/${{ matrix.job.target }}/release/zy${EXE_suffix}"
+        
+        if [ -n "${STRIP}" ]; then
+          "${STRIP}" "${ZY_BIN_PATH}"
+        fi
+
+        echo "ZY_BIN_PATH=${ZY_BIN_PATH}" >> $GITHUB_ENV
+
+    - name: Build archive
+      shell: bash
+      run: |
+        # zy-v0.1.4-x86_64-unknown-linux-gnu
+        ZY_PKG_BASENAME="zy-${{ env.ZY_VERSION }}-${{ matrix.target }}"
+        mkdir "$ZY_PKG_BASENAME"
+
+        cp "${ZY_BIN_PATH}" "$ZY_PKG_BASENAME/"
+        cp README.md LICENSE-MIT LICENSE-APACHE "$ZY_PKG_BASENAME/"
+
+        case ${{ matrix.job.target }} in
+          *-pc-windows-*)
+              ZY_PKG_PATH="${ZY_PKG_BASENAME}.zip"
+              7z -y a "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}"/*
+            ;;
+          *)
+              ZY_PKG_PATH="${ZY_PKG_BASENAME}.tar.gz"
+              tar czf "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}/*"
+            ;;
+        esac
+        echo "ZY_PKG_PATH=${ZY_PKG_PATH}" >> $GITHUB_ENV
+
+    - name: Publish archives and packages
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ env.ZY_PKG_PATH }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         case ${{ matrix.job.target }} in
           *-pc-windows-*)
               ZY_PKG_PATH="${ZY_PKG_BASENAME}.zip"
-              7z -y a "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}"/*
+              7z -y a "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}"/* | tail -2
             ;;
           *)
               ZY_PKG_PATH="${ZY_PKG_BASENAME}.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,17 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
-          - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
-          - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
-          - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-2019                  }
-          - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
-          - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
-          - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-10.15                   }
-          - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-2019                  }
-          - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-2019                  }
-          - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
-          - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
+          - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
+          - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
+          - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
+          - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
+          - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest , use-cross: true }
+          - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest , use-cross: true }
+          - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
+          - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
+          - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
+          - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest , use-cross: true }
+          - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
     - name: Get the release version from the tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
     - name: Install rust
       uses: dtolnay/rust-toolchain@stable
 
+    - uses: Swatinem/rust-cache@v2
+
     - uses: actions-rs/cargo@v1
       with:
         command: publish
@@ -161,18 +163,18 @@ jobs:
           macos-x86_64, win64-gnu, win64-msvc, linux-x86_64-gnu, linux-x86_64-musl
         ]
         include:
-        - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  }
+        - { name: 'linux-aarch64-gnu', target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
         - { name: 'macos-aarch64'    , target: aarch64-apple-darwin        , os: macos-latest  ,                 }
-        - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest  }
-        - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest  }
+        - { name: 'linux-arm-gnu'    , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-arm-musl'   , target: arm-unknown-linux-musleabihf, os: ubuntu-latest , use-cross: true }
         - { name: 'win32-msvc'       , target: i686-pc-windows-msvc        , os: windows-latest,                 }
-        - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest  }
-        - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest  }
+        - { name: 'linux-i686-gnu'   , target: i686-unknown-linux-gnu      , os: ubuntu-latest , use-cross: true }
+        - { name: 'linux-i686-musl'  , target: i686-unknown-linux-musl     , os: ubuntu-latest , use-cross: true }
         - { name: 'macos-x86_64'     , target: x86_64-apple-darwin         , os: macos-latest  ,                 }
         - { name: 'win64-gnu'        , target: x86_64-pc-windows-gnu       , os: windows-latest,                 }
         - { name: 'win64-msvc'       , target: x86_64-pc-windows-msvc      , os: windows-latest,                 }
-        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest  }
-        - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest  }
+        - { name: 'linux-x86_64-gnu' , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest                   }
+        - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
     - name: Checkout repository
@@ -203,7 +205,6 @@ jobs:
         args: --verbose --locked --profile ci-build --target=${{ matrix.target }}
 
     - name: Strip debug information from executable
-      id: strip
       shell: bash
       run: |
         EXE_suffix=""
@@ -220,9 +221,9 @@ jobs:
 
         PROJECT_BIN_PATH="target/${{ matrix.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
 
-        if [ -n "${STRIP}" ]; then
-          "${STRIP}" "${PROJECT_BIN_PATH}"
-        fi
+        # if [ -n "${STRIP}" ]; then
+        #   "${STRIP}" "${PROJECT_BIN_PATH}"
+        # fi
 
         echo "PROJECT_BIN_PATH=${PROJECT_BIN_PATH}" >> $GITHUB_ENV
 
@@ -252,7 +253,6 @@ jobs:
       uses: ffurrer2/extract-release-notes@c24866884b7a0d2fd2095be2e406b6f260479da8
 
     - name: Get contributors
-      id: get-contributors
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,11 +272,7 @@ jobs:
       run: |
         PRETTY_CONTRIBUTOR_LIST="@bulan-ci, @iTranscend and @miraclx"
         if [ -n "${PRETTY_CONTRIBUTOR_LIST}" ]; then
-          PRETTY_CONTRIBUTOR_LINE=" \
-            <sup> \
-              🎉  Thanks to ${{ env.PRETTY_CONTRIBUTOR_LIST }} for their contributions to this release. 🎉 \
-            </sup> \
-          "
+          PRETTY_CONTRIBUTOR_LINE="<sup> 🎉  Thanks to ${{ env.PRETTY_CONTRIBUTOR_LIST }} for their contributions to this release. 🎉 </sup>"
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ name: release
 on:
   push:
     branches:
-    - master
+    # - master
+    - ci/release-check
   workflow_dispatch:
     inputs:
       project-version:
@@ -133,6 +134,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: publish
+        args: --dry-run
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
             ;;
           *)
               ZY_PKG_PATH="${ZY_PKG_BASENAME}.tar.gz"
-              tar czf "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}/*"
+              tar czf "${ZY_PKG_PATH}" "${ZY_PKG_BASENAME}"/*
             ;;
         esac
         echo "ZY_PKG_PATH=${ZY_PKG_PATH}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   # Emit backtraces on panics.
   RUST_BACKTRACE: 1
   # Set to force version number, e.g., when no tag exists.
-  ZY_VERSION: TEST-0.0.0
+  ZY_VERSION: v0.1.5
     
 jobs:
   build-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
   binary:
     runs-on: ${{ matrix.os }}
     needs: check
-    # if: needs.check.outputs.should_release_binary == 'true'
+    if: needs.check.outputs.should_release_binary == 'true'
     env:
       STEP_NAME: binary
       PROJECT_NAME: ${{ needs.check.outputs.project_name }}
@@ -174,9 +174,6 @@ jobs:
         - { name: 'linux-x86_64-musl', target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
-    - shell: bash
-      run: exit 1
-
     - name: Checkout repository
       uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 #  - https://github.com/BurntSushi/ripgrep/blob/000015791742bb1280f1853adb714fdee1ba9f8e/.github/workflows/release.yml
 #  - https://github.com/near/near-cli-rs/blob/a8679a3603015f1d651f874fdf0feff0d7514131/.github/workflows/release.yml
 #  - https://github.com/sharkdp/bat/blob/7c847d84b0c3c97df6badfbb39d153ad93aec74e/.github/workflows/CICD.yml
+#  - https://github.com/near/near-jsonrpc-client-rs/blob/2a9cce4710bb87592baf5d7ca7015e3d474584e9/.github/workflows/ci.yml
 
 name: release
 
@@ -53,6 +54,9 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        # might be a simple `fetch-tags: true` option soon, see https://github.com/actions/checkout/pull/579
+        fetch-depth: 0
 
     - name: Install prerequisites
       shell: bash
@@ -105,10 +109,10 @@ jobs:
       run: |
         # zy-v0.1.4-x86_64-unknown-linux-gnu
         ZY_PKG_BASENAME="zy-${{ env.ZY_VERSION }}-${{ matrix.job.target }}"
-        mkdir "$ZY_PKG_BASENAME"
+        mkdir "${ZY_PKG_BASENAME}"
 
-        cp "${ZY_BIN_PATH}" "$ZY_PKG_BASENAME/"
-        cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "$ZY_PKG_BASENAME/"
+        cp "${ZY_BIN_PATH}" "${ZY_PKG_BASENAME}/"
+        cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "${ZY_PKG_BASENAME}/"
 
         case ${{ matrix.job.target }} in
           *-pc-windows-*)
@@ -122,9 +126,59 @@ jobs:
         esac
         echo "ZY_PKG_PATH=${ZY_PKG_PATH}" >> $GITHUB_ENV
 
+    - name: Extract release notes
+      id: extract-release-notes
+      uses: ffurrer2/extract-release-notes@c24866884b7a0d2fd2095be2e406b6f260479da8
+
+    - name: Get Contributors
+      id: get-contributors
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        DEFAULT_RELEASE_NOTE="$(
+          gh api \
+            /repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name='${{ env.ZY_VERSION }}' \
+            -q .body \
+        )"
+        echo "Default Release Note"
+        echo "${DEFAULT_RELEASE_NOTE}"
+        echo
+        CONTRIBUTORS="$(
+          <<< "${DEFAULT_RELEASE_NOTE}" \
+          perl -ne 'print if s/.+ by (@[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}) in https.+$/\1/i' \
+          | sort -u \
+        )"
+        echo "Contributors"
+        echo "${CONTRIBUTORS}"
+        echo
+        PRETTY_CONTRIBUTOR_LIST="$(
+          xargs <<< "${CONTRIBUTORS}" \
+          | sed 's/ /, /g;s/\(.*\), \(.*\)$/\1 and \2/' \
+        )"
+        echo "Prettified Contributors"
+        echo "${PRETTY_CONTRIBUTOR_LIST}"
+        echo
+        echo "PRETTY_CONTRIBUTOR_LIST=${PRETTY_CONTRIBUTOR_LIST}" >> $GITHUB_ENV
+
+    - name: Check Current Latest Tag
+      run: |
+        export GIT_PREVIOUS_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')"
+        echo "GIT_PREVIOUS_TAG=${GIT_PREVIOUS_TAG}" >> $GITHUB_ENV
+        echo "Current latest git release tag is \"${GIT_PREVIOUS_TAG}\""
+
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ env.ZY_VERSION }}
         files: ${{ env.ZY_PKG_PATH }}
         token: ${{ secrets.GITHUB_TOKEN }}
+        body: |
+          ## What's changed in ${{ matrix.job.target }}?
+        
+          ${{ steps.extract-release-notes.outputs.release_notes }}
+
+          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.ZY_VERSION }}
+          <sup>
+          🎉  Thanks to ${{ env.PRETTY_CONTRIBUTOR_LIST }} for their contributions to this release. 🎉
+          </sup>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
         CHANGELOG_LINE="**Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.PROJECT_VERSION }}"
         echo "CHANGELOG_LINE=${CHANGELOG_LINE}" >> $GITHUB_ENV
 
-    - name: Publish archives and packages
+    - name: Create release and upload artifacts
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ env.PROJECT_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,34 +204,17 @@ jobs:
         command: build
         args: --verbose --locked --profile ci-build --target=${{ matrix.target }}
 
-    - name: Strip debug information from executable
-      shell: bash
-      run: |
-        EXE_suffix=""
-        case ${{ matrix.target }} in
-          *-pc-windows-*) EXE_suffix=".exe" ;;
-        esac
-
-        STRIP="strip"
-        case ${{ matrix.target }} in
-          arm-unknown-linux-*) STRIP="arm-linux-gnueabihf-strip" ;;
-          aarch64-unknown-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;;
-          *-pc-windows-msvc) STRIP="" ;;
-        esac
-
-        PROJECT_BIN_PATH="target/${{ matrix.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
-
-        # if [ -n "${STRIP}" ]; then
-        #   "${STRIP}" "${PROJECT_BIN_PATH}"
-        # fi
-
-        echo "PROJECT_BIN_PATH=${PROJECT_BIN_PATH}" >> $GITHUB_ENV
-
     - name: Build archive
       shell: bash
       run: |
         PKG_BASENAME="${{ env.PROJECT_NAME }}-${{ env.PROJECT_VERSION }}-${{ matrix.target }}"
         mkdir "${PKG_BASENAME}"
+
+        EXE_suffix=""
+        case ${{ matrix.target }} in
+          *-pc-windows-*) EXE_suffix=".exe" ;;
+        esac
+        PROJECT_BIN_PATH="target/${{ matrix.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
 
         cp "${PROJECT_BIN_PATH}" "${PKG_BASENAME}/"
         cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "${PKG_BASENAME}/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
   crate:
     runs-on: ubuntu-latest
     needs: check
-    if: ${{ needs.check.outputs.has_released }} == 'false' && ${{ github.event_name }} != 'workflow_dispatch'
+    if: ${{ needs.check.outputs.has_released == 'false' && github.event_name != 'workflow_dispatch' }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,6 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |
-        gh --version
         DEFAULT_RELEASE_NOTE="$(
           curl -v \
             https://api.github.com/repos/miraclx/zy/releases/generate-notes \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       project_version: ${{ env.PROJECT_VERSION }}
       is_prerelease: ${{ env.IS_PRERELEASE }}
       has_released: ${{ env.HAS_RELEASED }}
+      publish_crate: ${{ env.HAS_RELEASED == 'false' && github.event_name != 'workflow_dispatch' }}
     env:
       HAS_RELEASED: false
       PROJECT_VERSION: ${{ github.event.inputs.project-version }}
@@ -79,14 +80,14 @@ jobs:
           IS_PRERELEASE=false
         fi
 
-        echo "PROJECT_VERSION=v${PROJECT_VERSION}" >> $GITHUB_ENV
+        echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
         echo "IS_PRERELEASE=${IS_PRERELEASE}" >> $GITHUB_ENV
         echo "HAS_RELEASED=${HAS_RELEASED}" >> $GITHUB_ENV
 
   crate:
     runs-on: ubuntu-latest
     needs: check
-    if: ${{ needs.check.outputs.has_released == 'false' && github.event_name != 'workflow_dispatch' }}
+    if: needs.check.outputs.publish_crate == 'true'
 
     steps:
     - name: Checkout repository
@@ -108,9 +109,11 @@ jobs:
     needs: check
     env:
       PROJECT_NAME: ${{ needs.check.outputs.project_name }}
-      PROJECT_VERSION: ${{ needs.check.outputs.project_version }}
+      PROJECT_VERSION: v${{ needs.check.outputs.project_version }}
+      RAW_PROJECT_VERSION: ${{ needs.check.outputs.raw_project_version }}
       IS_PRERELEASE: ${{ needs.check.outputs.is_prerelease }}
       HAS_RELEASED: ${{ needs.check.outputs.has_released }}
+      PUBLISH_CRATE: ${{ needs.check.outputs.publish_crate }}
     strategy:
       fail-fast: false
       matrix:
@@ -254,6 +257,11 @@ jobs:
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 
+        if [ "${{ env.PUBLISH_CRATE }}" = "true" ]; then
+          CRATE_LINE="**Crate Link**: https://crates.io/crates/${{ env.PROJECT_NAME }}/${{ env.RAW_PROJECT_VERSION }}"
+          echo "CRATE_LINE=${CRATE_LINE}" >> $GITHUB_ENV
+        fi
+
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
       with:
@@ -266,6 +274,8 @@ jobs:
           ## What's changed?
         
           ${{ steps.extract-release-notes.outputs.release_notes }}
+
+          ${{ env.CRATE_LINE }}
 
           **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.PROJECT_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
 env:
   PROJECT_INDEX_URL: https://raw.githubusercontent.com/rust-lang/crates.io-index/master/2/zy
   RUST_BACKTRACE: 1 # Emit backtraces on panics.
+  CARGO_PROFILE: slim # Use slim profile for release builds. Check the Cargo.toml for more context.
 
 jobs:
   check:
@@ -200,7 +201,7 @@ jobs:
       with:
         use-cross: ${{ matrix.use-cross }}
         command: build
-        args: --verbose --locked --profile ci-build --target=${{ matrix.target }}
+        args: --verbose --locked --profile=${{ env.CARGO_PROFILE }} --target=${{ matrix.target }}
 
     - name: Build archive
       shell: bash
@@ -212,7 +213,7 @@ jobs:
         case ${{ matrix.target }} in
           *-pc-windows-*) EXE_suffix=".exe" ;;
         esac
-        PROJECT_BIN_PATH="target/${{ matrix.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
+        PROJECT_BIN_PATH="target/${{ matrix.target }}/${{ env.CARGO_PROFILE }}/${{ env.PROJECT_NAME }}${EXE_suffix}"
 
         cp "${PROJECT_BIN_PATH}" "${PKG_BASENAME}/"
         cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "${PKG_BASENAME}/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,13 +270,12 @@ jobs:
     - name: Prepare release body
       shell: bash
       run: |
-        PRETTY_CONTRIBUTOR_LIST="@bulan-ci, @iTranscend and @miraclx"
         if [ -n "${PRETTY_CONTRIBUTOR_LIST}" ]; then
           PRETTY_CONTRIBUTOR_LINE="<sup> 🎉  Thanks to ${PRETTY_CONTRIBUTOR_LIST} for their contributions to this release. 🎉 </sup>"
           echo "PRETTY_CONTRIBUTOR_LINE=${PRETTY_CONTRIBUTOR_LINE}" >> $GITHUB_ENV
         fi
 
-        if [[ "${{ env.WILL_PUBLISH_CRATE }}" == "true" ]]; then
+        if [[ "${WILL_PUBLISH_CRATE}" == "true" ]]; then
           CRATE_LINE="**Crate Link**: https://crates.io/crates/${{ env.PROJECT_NAME }}/${{ env.RAW_PROJECT_VERSION }}"
           echo "CRATE_LINE=${CRATE_LINE}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ name: release
 on:
   push:
     branches:
-    # - master
-    - ci/release-check
+    - master
   workflow_dispatch:
     inputs:
       project-version:
@@ -134,7 +133,6 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: publish
-        args: --dry-run
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
     # name: binary (${{ matrix.job.name }})
     runs-on: ${{ matrix.job.os }}
     needs: check
-    if: needs.check.outputs.should_release_binary == 'true'
+    # if: needs.check.outputs.should_release_binary == 'true'
     env:
       STEP_NAME: binary
       PROJECT_NAME: ${{ needs.check.outputs.project_name }}
@@ -167,6 +167,9 @@ jobs:
     steps:
     - shell: bash
       run: echo "::job-name::binary (${{ matrix.job.name }})"
+
+    - shell: bash
+      run: exit 1
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           *-pc-windows-msvc) STRIP="" ;;
         esac
         
-        ZY_BIN_PATH="target/${{ matrix.job.target }}/release/zy${EXE_suffix}"
+        ZY_BIN_PATH="target/${{ matrix.job.target }}/ci-build/zy${EXE_suffix}"
         
         if [ -n "${STRIP}" ]; then
           "${STRIP}" "${ZY_BIN_PATH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ on:
 env:
   PROJECT_INDEX_URL: https://raw.githubusercontent.com/rust-lang/crates.io-index/master/2/zy
   RUST_BACKTRACE: 1 # Emit backtraces on panics.
-    
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -33,11 +33,12 @@ jobs:
       project_name: ${{ env.PROJECT_NAME }}
       project_version: ${{ env.PROJECT_VERSION }}
       is_prerelease: ${{ env.IS_PRERELEASE }}
-      has_released_crate: ${{ env.HAS_RELEASED_CRATE }}
-      should_publish_crate: ${{ env.HAS_RELEASED_CRATE == 'false' && github.event_name != 'workflow_dispatch' }}
       git_previous_tag: ${{ env.GIT_PREVIOUS_TAG }}
+      should_publish_crate: ${{ env.SHOULD_PUBLISH_CRATE }}
+      should_release_binary: ${{ env.SHOULD_RELEASE_BINARY }}
     env:
-      HAS_RELEASED_CRATE: false
+      SHOULD_PUBLISH_CRATE: false
+      SHOULD_RELEASE_BINARY: true
       PROJECT_VERSION: ${{ github.event.inputs.project-version }}
       IS_PRERELEASE: ${{ github.event.inputs.is-pre-release }}
 
@@ -68,32 +69,52 @@ jobs:
         fi
 
     - name: Version introspection
-      if: env.PROJECT_VERSION == ''
       run: |
-        PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
+        if [[ -z "${PROJECT_VERSION}" ]]; then
+          PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
+          echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
+        fi
         echo "Project version: ${PROJECT_VERSION}"
 
-        CRATE_VERSIONS=$(curl -s "${PROJECT_INDEX_URL}" | jq -r '.vers')
-        echo "Already published versions:\n${CRATE_VERSIONS}"
-        if echo "${CRATE_VERSIONS}" | grep -q "^${PROJECT_VERSION}$"; then
-          echo "Project version [${PROJECT_VERSION}] has already been released."
-          HAS_RELEASED_CRATE=true
-        else
-          echo "Project version [${PROJECT_VERSION}] has not been released."
-          HAS_RELEASED_CRATE=false
+        if [[ ! "${PROJECT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+          echo "Project version is not a valid semver: ${PROJECT_VERSION}"
+          exit 1
         fi
 
         if [[ "${PROJECT_VERSION}" == *-* ]]; then
           echo "Project version [${PROJECT_VERSION}] is a pre-release."
-          IS_PRERELEASE=true
+          echo "IS_PRERELEASE=true" >> $GITHUB_ENV
         else
           echo "Project version [${PROJECT_VERSION}] is not a pre-release."
-          IS_PRERELEASE=false
+          echo "IS_PRERELEASE=false" >> $GITHUB_ENV
         fi
 
-        echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
-        echo "HAS_RELEASED_CRATE=${HAS_RELEASED_CRATE}" >> $GITHUB_ENV
-        echo "IS_PRERELEASE=${IS_PRERELEASE}" >> $GITHUB_ENV
+    - name: Check if crates.io release exists
+      if: github.event_name != 'workflow_dispatch'
+      run: |
+        CRATE_VERSIONS=$(curl -s "${PROJECT_INDEX_URL}" | jq -r '.vers')
+        echo "Already published versions:\n${CRATE_VERSIONS}"
+
+        if echo "${CRATE_VERSIONS}" | grep -q "^${PROJECT_VERSION}$"; then
+          echo "Project version [${PROJECT_VERSION}] has already been released."
+          echo "SHOULD_PUBLISH_CRATE=false" >> $GITHUB_ENV
+        else
+          echo "Project version [${PROJECT_VERSION}] has not been released."
+          echo "SHOULD_PUBLISH_CRATE=true" >> $GITHUB_ENV
+        fi
+
+    - name: Check if GitHub release exists
+      run: |
+        RELEASED_VERSIONS=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*")
+        echo "Already released versions:\n${RELEASED_VERSIONS}"
+
+        if echo "${RELEASED_VERSIONS}" | grep -q "^v${PROJECT_VERSION}$"; then
+          echo "Project version [${PROJECT_VERSION}] has already been released."
+          echo "SHOULD_RELEASE_BINARY=false" >> $GITHUB_ENV
+        else
+          echo "Project version [${PROJECT_VERSION}] has not been released."
+          echo "SHOULD_RELEASE_BINARY=true" >> $GITHUB_ENV
+        fi
 
   crate:
     runs-on: ubuntu-latest
@@ -118,14 +139,14 @@ jobs:
     name: binary (${{ matrix.job.name }})
     runs-on: ${{ matrix.job.os }}
     needs: check
+    if: needs.check.outputs.should_release_binary == 'true'
     env:
       PROJECT_NAME: ${{ needs.check.outputs.project_name }}
       PROJECT_VERSION: v${{ needs.check.outputs.project_version }}
       RAW_PROJECT_VERSION: ${{ needs.check.outputs.project_version }}
       IS_PRERELEASE: ${{ needs.check.outputs.is_prerelease }}
-      HAS_RELEASED_CRATE: ${{ needs.check.outputs.has_released_crate }}
-      SHOULD_PUBLISH_CRATE: ${{ needs.check.outputs.should_publish_crate }}
       GIT_PREVIOUS_TAG: ${{ needs.check.outputs.git_previous_tag }}
+      SHOULD_PUBLISH_CRATE: ${{ needs.check.outputs.should_publish_crate }}
     strategy:
       fail-fast: false
       matrix:
@@ -181,9 +202,9 @@ jobs:
           aarch64-unknown-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;;
           *-pc-windows-msvc) STRIP="" ;;
         esac
-        
+
         PROJECT_BIN_PATH="target/${{ matrix.job.target }}/ci-build/${{ env.PROJECT_NAME }}${EXE_suffix}"
-        
+
         if [ -n "${STRIP}" ]; then
           "${STRIP}" "${PROJECT_BIN_PATH}"
         fi
@@ -278,7 +299,7 @@ jobs:
         files: ${{ env.PKG_PATH }}
         body: |
           ## What's changed?
-        
+
           ${{ steps.extract-release-notes.outputs.release_notes }}
 
           ${{ env.CRATE_LINE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2022-11-05
+
 - Support for the `PORT` environment variable.
 - Human cache time input (e.g. `1h`, `1year 6months`).
 - `--anonymize` flag to hide the `Server` and `X-Powered-By` headers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Support for the `PORT` environment variable.
+- Human cache time input (e.g. `1h`, `1year 6months`).
+- `--anonymize` flag to hide the `Server` and `X-Powered-By` headers.
+- Added `zstd` compression support.
+- Dynamic cache control (ETag, Last-Modified, Cache-Control).
+- Auto-served `index.html` files.
+- Use `println` over tracing for trivial logs.
+
+## [0.1.1] - 2022-10-30
+
+> Release Page: <https://github.com/miraclx/zy/releases/tag/v0.1.1>
+
+[unreleased]: https://github.com/miraclx/zy/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/miraclx/zy/releases/tag/v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.5] - 2022-11-05
-
 - Support for the `PORT` environment variable.
 - Human cache time input (e.g. `1h`, `1year 6months`).
 - `--anonymize` flag to hide the `Server` and `X-Powered-By` headers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.4"
+version = "0.1.4-pre.0"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.5"
+version = "0.1.4"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.4"
+version = "0.1.7"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.4-pre.0"
+version = "0.1.4"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.9"
+version = "0.1.5"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.8"
+version = "0.1.4"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.4"
+version = "0.1.7"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"
@@ -23,6 +23,6 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [profile.ci-build]
 inherits = "release"
-# lto = "thin"
+lto = true
 strip = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ color-eyre = "0.6.2"
 actix-files = "0.6.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
-[profile.ci-build]
+[profile.slim]
 inherits = "release"
 lto = true
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.4-pre.0"
+version = "0.1.4"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [profile.ci-build]
 inherits = "release"
-lto = "thin"
+# lto = "thin"
 strip = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.5"
+version = "0.1.4"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.8"
+version = "0.1.4"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.9"
+version = "0.1.5"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.4"
+version = "0.1.6"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.4"
+version = "0.1.4-pre.0"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,9 @@ humantime = "2.1.0"
 color-eyre = "0.6.2"
 actix-files = "0.6.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+
+[profile.ci-build]
+inherits = "release"
+lto = "thin"
+strip = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Installation
 
-To install `zy`, you need Rust `1.59.0` or higher. You can then use `cargo` to build everything:
+You can directly download any of the pre-built binaries from the [releases page](https://github.com/miraclx/zy/releases).
+
+Alternatively, to install `zy`, you need Rust `1.59.0` or higher. You can then use `cargo` to build everything:
 
 ```console
 cargo install zy

--- a/README.md
+++ b/README.md
@@ -17,19 +17,21 @@
 
 ## Installation
 
-You can directly download any of the pre-built binaries from the [releases page](https://github.com/miraclx/zy/releases).
+You can download any of the pre-compiled binaries from the [releases page](https://github.com/miraclx/zy/releases).
 
-Alternatively, to install `zy`, you need Rust `1.59.0` or higher. You can then use `cargo` to build everything:
+Or if you already have Rust installed, you can install it with `cargo`:
+
+> - Please, note that the minimum supported version of Rust for `zy` is `1.59.0`.
+> - Also, that the binary may be bigger than expected because it contains debug symbols. This is intentional. To remove debug symbols and therefore reduce the file size, you can instead run it with the `--profile slim` or simply just run `strip` on it.
 
 ```console
 cargo install zy
 ```
 
-You can also install the latest version (or a specific commit) of `zy` directly from GitHub.
+Alternatively, you can also build the latest version of `zy` directly from GitHub.
 
 ```console
-git clone https://github.com/miraclx/zy.git
-cargo install --path zy
+cargo install --git https://github.com/miraclx/zy.git
 ```
 
 ## Usage

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -50,6 +50,7 @@ where
         #[cfg(windows)]
         {
             let mut sigterm = signal::windows::ctrl_break()?;
+            sigterm.recv().await;
             info!("[signal] Ctrl-Break received");
         }
 

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -66,7 +66,14 @@ where
         }
 
         #[cfg(windows)]
-        std::future::pending::<()>().await;
+        {
+            match Some(1) {
+                Some(v) => return todo!(),
+                None => {}
+            };
+
+            std::future::pending::<()>().await;
+        }
 
         Result::<()>::Ok(())
     };

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -68,7 +68,7 @@ where
         #[cfg(windows)]
         {
             match Some(1) {
-                Some(v) => return todo!(),
+                Some(_v) => {}
                 None => {}
             };
 

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -66,14 +66,7 @@ where
         }
 
         #[cfg(windows)]
-        {
-            match Some(1) {
-                Some(_v) => {}
-                None => {}
-            };
-
-            std::future::pending::<()>().await;
-        }
+        std::future::pending::<()>().await;
 
         Result::<()>::Ok(())
     };


### PR DESCRIPTION
Introduces a CI workflow that automates GitHub releases as well as publishing to crates.io.

### How to update versions

- Submit a PR that bumps the version of the `Cargo.toml` file.
- Ensure the `Cargo.lock` file is also updated.
- Move all entries under the `Unreleased` section of the `CHANGELOG.md` file to a versioned section.
- Once the PR is merged, the release happens!

### How it works

Unlike most workflows, this doesn't trigger on a tag push. Instead, the first job in the workflow checks for a version bump to the `Cargo.toml` file when merged to master.

Alternatively, it can be triggered right from the GitHub Actions page, due to the `workflow_dispatch` event. Requiring you to specify a version. This flow, however, only releases to GitHub. And not to crates.io.

If a version bump was detected, and the new version hasn't yet been published, it spawns a job to publish it to crates.io. And if the version hasn't been released to GitHub, it spawns another job to release it.

The release job builds binaries for 12 targets, and publishes each one as an archive.

The final part of the release process is generation of release notes, embedding the latest changelog, including linking to the crate, as well as a credit line to the contributors of the release. Also marking it a pre-release, if it is one.

### Now for some cases

- If the version has already been published to crates.io and released to GitHub

   <img width="508" alt="CleanShot 2022-11-06 at 03 07 35@2x" src="https://user-images.githubusercontent.com/16881812/200148285-1529cf04-1dbf-40c8-ae62-c72d75caecb3.png">

- Publishing a new version and releasing it to GitHub

   <img width="510" alt="CleanShot 2022-11-06 at 03 08 43@2x" src="https://user-images.githubusercontent.com/16881812/200148278-a27a5150-ba0c-4f62-8e94-8783081b6eb6.png">

- The final release page

   <img width="860" alt="CleanShot 2022-11-06 at 04 13 21@2x" src="https://user-images.githubusercontent.com/16881812/200148273-a6cc6469-f5fc-4899-b886-a9e6c7b52f90.png">

- Final release page for a prerelease

<img width="934" alt="CleanShot 2022-11-06 at 08 28 33@2x" src="https://user-images.githubusercontent.com/16881812/200154221-6c845724-ff49-44ae-8f56-80616fd4d0b6.png">