### PR TITLE
chore: version to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.5] - 2022-11-05
+## [0.2.0] - 2022-11-06
 
 - Support for the `PORT` environment variable.
 - Human cache time input (e.g. `1h`, `1year 6months`).
@@ -21,5 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Release Page: <https://github.com/miraclx/zy/releases/tag/v0.1.1>
 
-[unreleased]: https://github.com/miraclx/zy/compare/v0.1.1...HEAD
+[unreleased]: https://github.com/miraclx/zy/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/miraclx/zy/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/miraclx/zy/releases/tag/v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "zy"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zy"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Miraculous Owonubi <omiraculous@gmail.com>"]
 edition = "2021"
 rust-version = "1.59.0"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can run `zy --help` to see all available options.
 
 ```console
 $ zy --help
-Zy 0.1.5
+Zy 0.2.0
 Minimal and blazing-fast file server.
 
 USAGE:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can run `zy --help` to see all available options.
 
 ```console
 $ zy --help
-Zy 0.1.4
+Zy 0.1.5
 Minimal and blazing-fast file server.
 
 USAGE:


### PR DESCRIPTION
Notable changes:

Tagged: https://github.com/miraclx/zy/releases/tag/v0.2.0

- Support for the `PORT` environment variable.
- Human cache time input (e.g. `1h`, `1year 6months`).
- `--anonymize` flag to hide the `Server` and `X-Powered-By` headers.
- Added `zstd` compression support.
- Dynamic cache control (ETag, Last-Modified, Cache-Control).
- Auto-served `index.html` files.
- Use `println` over tracing for trivial logs.

Check here for a full changelog: https://github.com/miraclx/zy/compare/v0.1.1...v0.2.0